### PR TITLE
Add Middleware for Old Slug Redirections to Enhance SEO and User Experience

### DIFF
--- a/sage_seo/admin/__init__.py
+++ b/sage_seo/admin/__init__.py
@@ -1,3 +1,4 @@
 from .meta_info import MetaInformationAdmin
 from .script_tag import ScriptTagAdmin
 from .url_redirect import URLRedirectAdmin
+from .slug_swap import SlugSwapAdmin

--- a/sage_seo/admin/slug_swap.py
+++ b/sage_seo/admin/slug_swap.py
@@ -1,0 +1,24 @@
+from django.contrib import admin
+
+from sage_seo.models import SlugSwap
+
+
+@admin.register(SlugSwap)
+class SlugSwapAdmin(admin.ModelAdmin):
+
+    list_display = ("new_slug", "old_slug", "redirect_type", "content_object")
+
+    list_editable = ("redirect_type",)
+
+    readonly_fields = (
+        "old_slug",
+        "new_slug",
+        "content_type",
+        "object_id",
+        "content_object",
+    )
+
+    search_fields = (
+        "old_slug",
+        "new_slug",
+    )

--- a/sage_seo/admin/url_redirect.py
+++ b/sage_seo/admin/url_redirect.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from ..models import URLRedirect
+from sage_seo.models import URLRedirect
 
 
 @admin.register(URLRedirect)

--- a/sage_seo/middleware/slug_swap.py
+++ b/sage_seo/middleware/slug_swap.py
@@ -1,0 +1,129 @@
+import logging
+from django.urls import reverse, NoReverseMatch
+from django.utils.deprecation import MiddlewareMixin
+from django.http import (
+    Http404,
+    HttpResponseRedirect as TemporaryRedirect,
+    HttpResponsePermanentRedirect as PermanentRedirect
+)
+from django.conf import settings
+from sage_seo.models import SlugSwap
+from sage_seo.helpers.enums import RedirectType
+
+logger = logging.getLogger(__name__)
+
+
+class OldSlugRedirectMiddleware(MiddlewareMixin):
+    """
+    Middleware to handle old slug redirection.
+
+    This middleware intercepts 404 responses and checks if the requested URL slug has
+    been changed. If an old slug is detected, it attempts to find the new slug and
+    redirects the user to the updated URL.
+
+    The middleware uses the `SLUG_TYPE_MAPPING` setting to determine the mappings
+    between URL parameter names and their respective content types. If a mapping is found,
+    it updates the URL parameters and performs a redirect based on the new slug information.
+
+    Example of SLUG_TYPE_MAPPING in settings:
+    SLUG_TYPE_MAPPING = {
+        'product_slug': 'product',
+        'category_slug': 'category',
+        'post_slug': 'post',
+        'slug': 'other',
+    }
+
+    The middleware performs the following steps:
+    1. Intercepts 404 responses.
+    2. Retrieves the old slug from the request.
+    3. Uses the mapping defined in SLUG_TYPE_MAPPING to find the new slug.
+    4. Constructs the new URL and redirects the user.
+    5. Logs any errors encountered during the process.
+
+    This helps maintain SEO and user experience by ensuring that outdated links
+    continue to direct users to the correct content.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+        super().__init__(get_response)
+
+    def process_response(self, request, response):
+        """
+        Processes the response to check for 404 errors and handle old slug redirection.
+
+        This method intercepts 404 responses, checks for old slugs in the request,
+        and attempts to find and redirect to the new slug using the SLUG_TYPE_MAPPING
+        settings.
+
+        If the requested URL matches an old slug, the method constructs a new URL
+        with the updated slug and performs a redirect to the new URL.
+
+        """
+        if response.status_code == 404:
+            try:
+                updated_kwargs = {}
+
+                for slug_name, slug_type in settings.SLUG_TYPE_MAPPING.items():
+                    old_slug = request.resolver_match.kwargs.get(slug_name)
+                    if old_slug:
+                        updated_kwargs[slug_name] = self._get_new_slug(old_slug, slug_type)
+
+                if updated_kwargs:
+                    try:
+                        new_url = reverse(request.resolver_match.view_name, kwargs=updated_kwargs)
+                        return self._redirect(new_url, updated_kwargs)
+                    except NoReverseMatch as e:
+                        logger.error(f'NoReverseMatch: {e} for view {request.resolver_match.view_name} with kwargs {updated_kwargs}')
+                        raise Http404('Page not found.')
+
+            except AttributeError as e:
+                logger.warning(f'AttributeError: {e} in OldSlugRedirectMiddleware')
+            except Exception as e:
+                logger.error(f'Unexpected error: {e} in OldSlugRedirectMiddleware')
+
+        return response
+
+    def _get_new_slug(self, old_slug, slug_type):
+        """
+        Retrieves the new slug for the given old slug and content type.
+
+        This method checks if there is a new slug associated with the given old slug
+        and content type. If a new slug is found, it is returned; otherwise, the old
+        slug is returned.
+        """
+        try:
+            slug_swap = SlugSwap.objects.filter(old_slug=old_slug, content_type__model=slug_type).first()
+            if slug_swap:
+                return slug_swap.new_slug
+            return old_slug
+        except SlugSwap.DoesNotExist:
+            return old_slug
+        except Exception as e:
+            logger.error(f'Error retrieving new slug for {old_slug} of type {slug_type}: {e}')
+            return old_slug
+
+    def _redirect(self, url, updated_kwargs):
+        """
+        Redirects to the new URL based on the updated slug.
+
+        This method performs a redirection to the new URL constructed with the updated
+        slug. It determines whether to perform a permanent or temporary redirect based
+        on the redirect type defined in the SlugSwap model.
+
+        """
+        try:
+            slug_swap = SlugSwap.objects.filter(
+                old_slug=updated_kwargs.get('product_slug') or
+                updated_kwargs.get('post_slug') or
+                updated_kwargs.get('category_slug') or
+                updated_kwargs.get('slug')
+            ).first()
+            if slug_swap:
+                if slug_swap.redirect_type == RedirectType.Primary:
+                    return PermanentRedirect(url)
+                else:
+                    return TemporaryRedirect(url)
+            return TemporaryRedirect(url)
+        except Exception as e:
+            logger.error(f'Error during redirect to {url} with kwargs {updated_kwargs}: {e}')
+            return TemporaryRedirect(url)

--- a/sage_seo/middleware/url_redirect.py
+++ b/sage_seo/middleware/url_redirect.py
@@ -1,0 +1,74 @@
+import logging
+import re
+from django.shortcuts import redirect
+from django.utils.deprecation import MiddlewareMixin
+from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
+from django.urls import resolve, Resolver404
+
+from ..models import URLRedirect
+from ..helpers.enums import RedirectType
+
+logger = logging.getLogger(__name__)
+
+
+class URLRedirectMiddleware(MiddlewareMixin):
+    """
+    Middleware to handle URL redirection based on database entries.
+
+    This middleware intercepts responses with a 404 status code,
+    checks if there is a mapping for the requested URL in the `URLRedirect` model,
+    and if found, redirects the user to the new URL.
+    This is useful for managing URL changes and ensuring that users and search engines are redirected to the
+    correct pages without encountering broken links.
+
+    """
+
+    def __init__(self, get_response):
+        """
+        This method sets up the middleware by storing the get_response function,
+        which represents the next middleware or view to be called.
+        The super() call ensures proper initialization of the base class.
+        """
+        self.get_response = get_response
+        super().__init__(get_response)
+
+    def process_response(self, request, response):
+        """
+        This method checks if the response has a 404 status code,
+        indicating that the requested URLwas not found.
+        If a 404 is detected, it attempts to find a new URL for the requested old URLusing the `get_new_url` method.
+        If a mapping is found, it returns a permanent redirect response to the new URL.
+        """
+        old_url = request.path
+
+        # Check for 404 status code
+        if response.status_code == 404:
+            new_url = self.get_new_url(old_url)
+            if new_url:
+                # Redirect to the new URL
+                return HttpResponsePermanentRedirect(new_url)
+
+        return response
+
+    def url_exists_in_urlpatterns(self, url):
+        """
+        This method attempts to resolve the given URL using Django's URL resolver.
+        If the URL can be resolved without raising a `Resolver404` exception,
+        it returns True, indicating that the URL exists in the current URL patterns.
+        """
+        try:
+            resolve(url)
+            return True
+        except Resolver404:
+            return False
+
+    def get_new_url(self, old_url):
+        """
+        This method queries the `URLRedirect` model to find a mapping for the given old URL.
+        If a mapping exists, it returns the new URL. If no mapping is found, it returns None.
+        """
+        try:
+            url_mapping = URLRedirect.objects.get(old_url=old_url)
+            return url_mapping.new_url
+        except URLRedirect.DoesNotExist:
+            return None

--- a/sage_seo/middleware/url_redirect.py
+++ b/sage_seo/middleware/url_redirect.py
@@ -5,8 +5,8 @@ from django.utils.deprecation import MiddlewareMixin
 from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.urls import resolve, Resolver404
 
-from ..models import URLRedirect
-from ..helpers.enums import RedirectType
+from sage_seo.models import URLRedirect
+from sage_seo.helpers.enums import RedirectType
 
 logger = logging.getLogger(__name__)
 

--- a/sage_seo/models/__init__.py
+++ b/sage_seo/models/__init__.py
@@ -1,3 +1,4 @@
 from .meta_info import MetaInformation
 from .script_tag import ScriptTag
 from .url_redirect import URLRedirect
+from .slug_swap import SlugSwap

--- a/sage_seo/models/slug_swap.py
+++ b/sage_seo/models/slug_swap.py
@@ -1,0 +1,67 @@
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+from django.core.validators import MaxLengthValidator
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from sage_seo.helpers.enums import RedirectType
+
+
+class SlugSwap(models.Model):
+    """
+    The SlugSwap model is used to manage and record the changes in slugs for different
+    objects. It helps in redirecting old URLs to new ones, thereby maintaining SEO and
+    ensuring that links do not break when slugs are updated.
+
+    Example of usage:
+        When an object's slug is updated, an entry in SlugSwap can be created to map the old slug
+        to the new slug. This allows for automatic redirection from the old URL to the new URL.
+
+    """
+    old_slug = models.SlugField(
+        _("Old Slug"),
+        max_length=255,
+        editable=False,
+        allow_unicode=True,
+        help_text=_(
+            "Slug is a newspaper term. A short label for "
+            "something containing only letters, numbers, underscores, "
+            "or hyphens. They are generally used in URLs."
+        ),
+    )
+
+    new_slug = models.SlugField(
+        _("New Slug"),
+        max_length=255,
+        editable=False,
+        allow_unicode=True,
+        help_text=_(
+            "Slug is a newspaper term. A short label for "
+            "something containing only letters, numbers, underscores, "
+            "or hyphens. They are generally used in URLs."
+        ),
+    )
+
+    content_type = models.ForeignKey(
+        ContentType,
+        on_delete=models.CASCADE,
+        help_text=_("Content type of the related object."),
+    )
+    object_id = models.PositiveIntegerField(help_text=_("ID of the related object."))
+    content_object = GenericForeignKey("content_type", "object_id")
+
+    redirect_type = models.CharField(
+        _("redirect type"),
+        max_length=20,
+        validators=[MaxLengthValidator(20)],
+        choices=RedirectType.choices,
+        default=RedirectType.Primary,
+        help_text=_(
+            "refers to the HTTP status code that is used to"
+            "redirect a user from one URL to another"
+        ),
+    )
+
+    class Meta:
+        verbose_name = _("Slug Swap")
+        verbose_name_plural = _("Slug Swaps")

--- a/sage_seo/models/url_redirect.py
+++ b/sage_seo/models/url_redirect.py
@@ -4,8 +4,8 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 from sage_tools.mixins.models.base import TimeStampMixin
 
-from ..helpers.enums import RedirectType
-from .validators import validate_url_format
+from sage_seo.helpers.enums import RedirectType
+from sage_seo.models.validators import validate_url_format
 
 
 class URLRedirect(TimeStampMixin):


### PR DESCRIPTION
### Overview

This pull request introduces the `OldSlugRedirectMiddleware`, which aims to improve SEO and user experience by handling old slug redirections seamlessly. When a URL slug is updated, this middleware ensures that users accessing the old slug are automatically redirected to the new URL, preventing broken links and maintaining link integrity.

### Key Features

- **Middleware Implementation**: 
  - Added `OldSlugRedirectMiddleware` to intercept 404 responses and check for outdated slugs.
  - Utilizes `SLUG_TYPE_MAPPING` from the settings to dynamically map old slugs to new ones.

- **Slug Mapping and Redirection**: 
  - Retrieves old slugs from the request and maps them to their new counterparts.
  - Constructs new URLs and performs appropriate redirects (temporary or permanent) based on the configuration.

- **Error Handling and Logging**: 
  - Comprehensive error handling to log issues and handle exceptions, ensuring robustness.
  - Detailed logging for easier debugging and maintenance.

### Benefits

- **SEO Improvement**: 
  - Maintains search engine rankings by ensuring that old links remain valid.
  - Prevents 404 errors which can negatively impact SEO.

- **Enhanced User Experience**: 
  - Users accessing outdated URLs are seamlessly redirected to the correct pages.
  - Prevents frustration from broken links and improves overall site navigation.

### Example Configuration

To enable this feature, add the following configuration to your settings:

```python
SLUG_TYPE_MAPPING = {
    'product_slug': 'product',
    'your_slug': 'your_model_type',
   'your_slug2': 'your_model_typ2e',
}
```


### Closing Issues

This pull request closes issue #1