### PR TITLE
fix(MetaKeyMixin): make mixin abstract = True

### DIFF
--- a/sage_seo/models/mixins/seo.py
+++ b/sage_seo/models/mixins/seo.py
@@ -29,6 +29,9 @@ class MetaKeyMixin(models.Model):
         verbose_name=_("SEO Description"), null=True, blank=True
     )
 
+    class Meta:
+        abstract = True
+
 
 class OGMixin(models.Model):
     """


### PR DESCRIPTION


This PR makes the `MetaKeyMixin` abstract to resolve a `ValueError: Can't bulk create a multi-table inherited model`.
**Reason:**
- This change prevents Django from creating a separate table for the mixin, which was causing the bulk create error.

#8 